### PR TITLE
Added support for Arduino Leonardo and Due and fix #9

### DIFF
--- a/Arduinoboy/Arduinoboy.ino
+++ b/Arduinoboy/Arduinoboy.ino
@@ -10,8 +10,8 @@
  ***************************************************************************
  ***************************************************************************
  *                                                                         *
- * Version: 1.3.0a                                                         *
- * Date:    July 10 2016                                                   *
+ * Version: 1.3.3                                                          *
+ * Date:    May 17 2020                                                    *
  * Name:    Timothy Lamb                                                   *
  * Email:   trash80@gmail.com                                              *
  *                                                                         *
@@ -20,7 +20,7 @@
  *                                                                         *
  * NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE   *
  *                                                                         *
- *  http://code.google.com/p/arduinoboy/                                   *
+ *  https://github.com/trash80/Arduinoboy                                  *
  *                                                                         *
  *   Arduino pin settings:  (Layout is final)                              *
  *     - 6 LEDS on pins 8 to 13                                            *
@@ -75,7 +75,6 @@
  *   (at your option) any later version.                                   *
  *                                                                         *
  ***************************************************************************/
-#include <EEPROM.h>
 #define MEM_MAX 65
 #define NUMBER_OF_MODES 7    //Right now there are 7 modes, Might be more in the future
 
@@ -109,8 +108,6 @@
 /***************************************************************************
 * User Settings
 ***************************************************************************/
-
-boolean alwaysUseDefaultSettings = false; //set to true to always use the settings below, else they are pulled from memory for the software editor
 
 boolean usbMode                  = false; //to use usb for serial communication as oppose to MIDI - sets baud rate to 38400
 
@@ -149,7 +146,7 @@ byte memory[MEM_MAX];
 
 
 /***************************************************************************
-* Teensy 3.2, Teensy 3.0, Teensy LC
+* Teensy 3.2, Teensy LC
 *
 * Notes on Teensy: Pins are not the same as in the schematic, the mapping is below.
 * Feel free to change, all related config in is this block.
@@ -157,6 +154,8 @@ byte memory[MEM_MAX];
 ***************************************************************************/
 #if defined (__MK20DX256__) || defined (__MK20DX128__) || defined (__MKL26Z64__)
 #define USE_TEENSY 1
+#define USE_USB 1
+#include <MIDI.h>
 
 #if defined (__MKL26Z64__)
 #define GB_SET(bit_cl,bit_out,bit_in) GPIOB_PDOR = ((bit_in<<3) | (bit_out<<1) | bit_cl)
@@ -175,9 +174,78 @@ int pinButtonMode = 2; //toggle button for selecting the mode
 HardwareSerial *serial = &Serial1;
 
 /***************************************************************************
-* Arudino Atmega 328 (assumed)
+* Arduino Leonardo/Yún/Micro (ATmega32U4)
+***************************************************************************/
+#elif defined (__AVR_ATmega32U4__)
+#define USE_LEONARDO
+#include <MIDIUSB.h>
+#include <PS2Keyboard.h>
+
+// values for the PS/2 Keyboard input
+#define PS2_DATA_PIN 7
+#define PS2_CLOCK_PIN 3
+PS2Keyboard keyboard;
+#define GB_SET(bit_cl, bit_out, bit_in) PORTF = (PINF & B00011111) | ((bit_cl<<7) | ((bit_out)<<6) | ((bit_in)<<5))
+// ^ The reason for not using digitalWrite is to allign clock and data pins for the GB shift reg.
+// Pin distribution comes from official Arduino Leonardo documentation
+
+int pinGBClock     = A0;    // Analog In 0 - clock out to gameboy
+int pinGBSerialOut = A1;    // Analog In 1 - serial data to gameboy
+int pinGBSerialIn  = A2;    // Analog In 2 - serial data from gameboy
+int pinMidiInputPower = 4; // power pin for midi input opto-isolator
+int pinStatusLed = 13; // Status LED
+int pinLeds[] = {12,11,10,9,8,13}; // LED Pins
+int pinButtonMode = 3; //toggle button for selecting the mode
+
+HardwareSerial *serial = &Serial1;
+
+byte incomingPS2Byte;
+
+
+/***************************************************************************
+* Arduino Due (ATmSAM3X8E)
+***************************************************************************/
+#elif defined (__SAM3X8E__)
+#define USE_DUE
+
+#define USE_LEONARDO
+#include <MIDIUSB.h>
+#include <PS2Keyboard.h>
+#include <digitalWriteFast.h>
+
+
+// values for the PS/2 Keyboard input
+#define PS2_DATA_PIN 7
+#define PS2_CLOCK_PIN 3
+PS2Keyboard keyboard;
+
+
+#define GB_SET(bit_cl, bit_out, bit_in) digitalWriteFast(A0, bit_cl); digitalWriteFast(A1, bit_out); digitalWriteFast(A2, bit_in);
+// ^ The reason for not using digitalWrite is to allign clock and data pins for the GB shift reg.
+
+int pinGBClock     = A0;    // Analog In 0 - clock out to gameboy
+int pinGBSerialOut = A1;    // Analog In 1 - serial data to gameboy
+int pinGBSerialIn  = A2;    // Analog In 2 - serial data from gameboy
+int pinMidiInputPower = 4; // power pin for midi input opto-isolator
+int pinStatusLed = 13; // Status LED
+int pinLeds[] = {12,11,10,9,8,13}; // LED Pins
+int pinButtonMode = 3; //toggle button for selecting the mode
+
+HardwareSerial *serial = &Serial;
+
+byte incomingPS2Byte;
+
+
+/***************************************************************************
+* Arduino UNO/Ethernet/Nano (ATmega328) or Mega 2560 (ATmega2560) (assumed)
 ***************************************************************************/
 #else
+#include <PS2Keyboard.h>
+
+// values for the PS/2 Keyboard input
+#define PS2_DATA_PIN 7
+#define PS2_CLOCK_PIN 3
+PS2Keyboard keyboard;
 #define GB_SET(bit_cl,bit_out,bit_in) PORTC = (PINC & B11111000) | ((bit_in<<2) | ((bit_out)<<1) | bit_cl)
 // ^ The reason for not using digitalWrite is to allign clock and data pins for the GB shift reg.
 
@@ -191,11 +259,19 @@ int pinButtonMode = 3; //toggle button for selecting the mode
 
 HardwareSerial *serial = &Serial;
 
+byte incomingPS2Byte;
+
 #endif
 
 /***************************************************************************
 * Memory
 ***************************************************************************/
+#ifndef USE_DUE
+    #include <EEPROM.h>
+    boolean alwaysUseDefaultSettings = false; //set to true to always use the settings below, else they are pulled from memory for the software editor
+#else
+    boolean alwaysUseDefaultSettings = true; //set to true to always use the default settings, in Due board is necessary as it doesn't have EEPROM
+#endif
 
 int eepromMemoryByte = 0; //Location of where to store settings from mem
 
@@ -362,7 +438,6 @@ uint8_t mapQueueWaitUsb = 5; //5ms - Needs to be longer because message packet i
 ***************************************************************************/
 #define GB_MIDI_DELAY 500 //Microseconds to delay the sending of a byte to gb
 
-
 void setup() {
 /*
   Init Memory
@@ -383,7 +458,7 @@ void setup() {
   Set MIDI Serial Rate
 */
 
-#ifdef USE_TEENSY
+#ifdef USE_USB
   serial->begin(31250); //31250
 #else
   if(usbMode == true) {
@@ -391,7 +466,11 @@ void setup() {
   } else {
     pinMode(pinMidiInputPower,OUTPUT);
     digitalWrite(pinMidiInputPower,HIGH); // turn on the optoisolator
-    Serial.begin(31250); //31250
+    #ifdef USE_LEONARDO
+      Serial1.begin(31250); //31250
+    #else
+      Serial.begin(31250); //31250
+    #endif
   }
 #endif
 
@@ -422,7 +501,9 @@ void setup() {
 /*
   Load Settings from EEPROM
 */
+  #ifndef USE_DUE
   if(!memory[MEM_FORCE_MODE]) memory[MEM_MODE] = EEPROM.read(MEM_MODE);
+  #endif
   lastMode = memory[MEM_MODE];
 
 /*

--- a/Arduinoboy/Led_Functions.ino
+++ b/Arduinoboy/Led_Functions.ino
@@ -109,7 +109,27 @@ void blinkLight(byte midiMessage, byte midiValue)
       blinkSwitch[0]=1;
       blinkSwitchTime[0]=0;
       break;
+    case 0x95:
+      if(!blinkSwitch[0]) digitalWrite(pinLeds[0],HIGH);
+      blinkSwitch[0]=1;
+      blinkSwitchTime[0]=0;
+      break;
+    case 0x9A:
+      if(!blinkSwitch[0]) digitalWrite(pinLeds[0],HIGH);
+      blinkSwitch[0]=1;
+      blinkSwitchTime[0]=0;
+      break;
     case 0x91:
+      if(!blinkSwitch[1]) digitalWrite(pinLeds[1],HIGH);
+      blinkSwitch[1]=1;
+      blinkSwitchTime[1]=0;
+      break;
+    case 0x96:
+      if(!blinkSwitch[1]) digitalWrite(pinLeds[1],HIGH);
+      blinkSwitch[1]=1;
+      blinkSwitchTime[1]=0;
+      break;
+    case 0x9B:
       if(!blinkSwitch[1]) digitalWrite(pinLeds[1],HIGH);
       blinkSwitch[1]=1;
       blinkSwitchTime[1]=0;
@@ -119,12 +139,54 @@ void blinkLight(byte midiMessage, byte midiValue)
       blinkSwitch[2]=1;
       blinkSwitchTime[2]=0;
       break;
+    case 0x97:
+      if(!blinkSwitch[2]) digitalWrite(pinLeds[2],HIGH);
+      blinkSwitch[2]=1;
+      blinkSwitchTime[2]=0;
+      break;
+    case 0x9C:
+      if(!blinkSwitch[2]) digitalWrite(pinLeds[2],HIGH);
+      blinkSwitch[2]=1;
+      blinkSwitchTime[2]=0;
+      break;
     case 0x93:
       if(!blinkSwitch[3]) digitalWrite(pinLeds[3],HIGH);
       blinkSwitch[3]=1;
       blinkSwitchTime[3]=0;
       break;
+    case 0x98:
+      if(!blinkSwitch[3]) digitalWrite(pinLeds[3],HIGH);
+      blinkSwitch[3]=1;
+      blinkSwitchTime[3]=0;
+      break;
+    case 0x9D:
+      if(!blinkSwitch[3]) digitalWrite(pinLeds[3],HIGH);
+      blinkSwitch[3]=1;
+      blinkSwitchTime[3]=0;
+      break;
     case 0x94:
+      if(!blinkSwitch[0])  digitalWrite(pinLeds[0],HIGH);
+      blinkSwitch[0]=1;
+      blinkSwitchTime[0]=0;
+      if(!blinkSwitch[1]) digitalWrite(pinLeds[1],HIGH);
+      blinkSwitch[1]=1;
+      blinkSwitchTime[1]=0;
+      if(!blinkSwitch[2]) digitalWrite(pinLeds[2],HIGH);
+      blinkSwitch[2]=1;
+      blinkSwitchTime[2]=0;
+      break;
+    case 0x99:
+      if(!blinkSwitch[0])  digitalWrite(pinLeds[0],HIGH);
+      blinkSwitch[0]=1;
+      blinkSwitchTime[0]=0;
+      if(!blinkSwitch[1]) digitalWrite(pinLeds[1],HIGH);
+      blinkSwitch[1]=1;
+      blinkSwitchTime[1]=0;
+      if(!blinkSwitch[2]) digitalWrite(pinLeds[2],HIGH);
+      blinkSwitch[2]=1;
+      blinkSwitchTime[2]=0;
+      break;
+    case 0x9E:
       if(!blinkSwitch[0])  digitalWrite(pinLeds[0],HIGH);
       blinkSwitch[0]=1;
       blinkSwitchTime[0]=0;

--- a/Arduinoboy/Memory_Functions.ino
+++ b/Arduinoboy/Memory_Functions.ino
@@ -2,23 +2,27 @@
 boolean checkMemory()
 {
   byte chk;
+  #ifndef USE_DUE
   for(int m=0;m<4;m++){
     chk =  EEPROM.read(MEM_CHECK+m);
     if(chk != defaultMemoryMap[MEM_CHECK+m]) {
       return false;
     }
   }
+  #endif
   return true;
 }
 
 void initMemory(boolean reinit)
 {
   if(!alwaysUseDefaultSettings) {
+    #ifndef USE_DUE
     if(reinit || !checkMemory()) {
       for(int m=(MEM_MAX);m>=0;m--){
         EEPROM.write(m,defaultMemoryMap[m]);
       }
     }
+    #endif
     loadMemory();
   } else {
     for(int m=0;m<=MEM_MAX;m++){
@@ -31,9 +35,11 @@ void initMemory(boolean reinit)
 
 void loadMemory()
 {
+  #ifndef USE_DUE
   for(int m=(MEM_MAX);m>=0;m--){
      memory[m] = EEPROM.read(m);
   }
+  #endif
   changeTasks();
 }
 
@@ -46,10 +52,12 @@ void printMemory()
 
 void saveMemory()
 {
+  #ifndef USE_DUE
   for(int m=(MEM_MAX-1);m>=0;m--){
     EEPROM.write(m,memory[m]);
   }
   changeTasks();
+  #endif
 }
 
 void changeTasks()

--- a/Arduinoboy/Mode.ino
+++ b/Arduinoboy/Mode.ino
@@ -30,7 +30,9 @@ void setMode()
   if(!memory[MEM_FORCE_MODE] && buttonDepressed) { //if the button is pressed
     memory[MEM_MODE]++;                           //increment the mode number
     if(memory[MEM_MODE] > (NUMBER_OF_MODES - 1)) memory[MEM_MODE]=0;  //if the mode is greater then 4 it will wrap back to 0
+    #ifndef USE_DUE
     if(!memory[MEM_FORCE_MODE]) EEPROM.write(MEM_MODE, memory[MEM_MODE]); //write mode to eeprom if we arnt forcing a mode in the config
+    #endif
     showSelectedMode();            //set the LEDS
     switchMode();
   }
@@ -110,5 +112,3 @@ void sequencerStop()
   digitalWrite(pinLeds[3],LOW);
   digitalWrite(pinLeds[memory[MEM_MODE]],HIGH);
 }
-
-

--- a/Arduinoboy/Mode_MidiGb.ino
+++ b/Arduinoboy/Mode_MidiGb.ino
@@ -17,7 +17,7 @@ void modeMidiGbSetup()
   pinMode(pinGBClock,OUTPUT);
   digitalWrite(pinGBClock,HIGH);
 
-#ifdef MIDI_INTERFACE
+#ifdef USE_TEENSY
   usbMIDI.setHandleRealTimeSystem(NULL);
 #endif
 
@@ -121,7 +121,7 @@ void sendByteToGameboy(byte send_byte)
 
 void modeMidiGbUsbMidiReceive()
 {
-#ifdef MIDI_INTERFACE
+#ifdef USE_TEENSY
 
     while(usbMIDI.read()) {
         uint8_t ch = usbMIDI.getChannel() - 1;
@@ -145,10 +145,10 @@ void modeMidiGbUsbMidiReceive()
         if(!send) return;
         uint8_t s;
         switch(usbMIDI.getType()) {
-            case 0: // note off
-            case 1: // note on
+            case 0x80: // note off
+            case 0x90: // note on
                 s = 0x90 + ch;
-                if(!usbMIDI.getType()) {
+                if(usbMIDI.getType() == 0x80) {
                     s = 0x80 + ch;
                 }
                 sendByteToGameboy(s);
@@ -159,7 +159,7 @@ void modeMidiGbUsbMidiReceive()
                 delayMicroseconds(GB_MIDI_DELAY);
                 blinkLight(s, usbMIDI.getData2());
             break;
-            case 3: // CC
+            case 0xB0: // CC
                 sendByteToGameboy(0xB0+ch);
                 delayMicroseconds(GB_MIDI_DELAY);
                 sendByteToGameboy(usbMIDI.getData1());
@@ -168,14 +168,14 @@ void modeMidiGbUsbMidiReceive()
                 delayMicroseconds(GB_MIDI_DELAY);
                 blinkLight(0xB0+ch, usbMIDI.getData2());
             break;
-            case 4: // PG
+            case 0xC0: // PG
                 sendByteToGameboy(0xC0+ch);
                 delayMicroseconds(GB_MIDI_DELAY);
                 sendByteToGameboy(usbMIDI.getData1());
                 delayMicroseconds(GB_MIDI_DELAY);
                 blinkLight(0xC0+ch, usbMIDI.getData2());
             break;
-            case 6: // PB
+            case 0xE0: // PB
                 sendByteToGameboy(0xE0+ch);
                 delayMicroseconds(GB_MIDI_DELAY);
                 sendByteToGameboy(usbMIDI.getData1());
@@ -187,5 +187,80 @@ void modeMidiGbUsbMidiReceive()
 
         statusLedOn();
     }
+#endif
+
+#ifdef USE_LEONARDO
+
+    midiEventPacket_t rx;
+      do
+      {
+        rx = MidiUSB.read();
+        uint8_t ch = rx.byte1 & 0x0F;
+        boolean send = false;
+        if(ch == memory[MEM_MGB_CH]) {
+            ch = 0;
+            send = true;
+        } else if (ch == memory[MEM_MGB_CH+1]) {
+            ch = 1;
+            send = true;
+        } else if (ch == memory[MEM_MGB_CH+2]) {
+            ch = 2;
+            send = true;
+        } else if (ch == memory[MEM_MGB_CH+3]) {
+            ch = 3;
+            send = true;
+        } else if (ch == memory[MEM_MGB_CH+4]) {
+            ch = 4;
+            send = true;
+        }
+        if (!send) return;
+        uint8_t s;
+        switch (rx.header)
+        {
+        case 0x08: // note off
+        case 0x09: // note on
+          s = 0x90 + ch;
+          if (rx.header == 0x08)
+          {
+            s = 0x80 + ch;
+          }
+          sendByteToGameboy(s);
+          delayMicroseconds(GB_MIDI_DELAY);
+          sendByteToGameboy(rx.byte2);
+          delayMicroseconds(GB_MIDI_DELAY);
+          sendByteToGameboy(rx.byte3);
+          delayMicroseconds(GB_MIDI_DELAY);
+          blinkLight(s, rx.byte2);
+          break;
+        case 0x0B: // CC
+          sendByteToGameboy(0xB0 + ch);
+          delayMicroseconds(GB_MIDI_DELAY);
+          sendByteToGameboy(rx.byte2);
+          delayMicroseconds(GB_MIDI_DELAY);
+          sendByteToGameboy(rx.byte3);
+          delayMicroseconds(GB_MIDI_DELAY);
+          blinkLight(0xB0 + ch, rx.byte2);
+          break;
+        case 0x0C: // PG
+          sendByteToGameboy(0xC0 + ch);
+          delayMicroseconds(GB_MIDI_DELAY);
+          sendByteToGameboy(rx.byte2);
+          delayMicroseconds(GB_MIDI_DELAY);
+          blinkLight(0xC0 + ch, rx.byte2);
+          break;
+        case 0x0E: // PB
+          sendByteToGameboy(0xE0 + ch);
+          delayMicroseconds(GB_MIDI_DELAY);
+          sendByteToGameboy(rx.byte2);
+          delayMicroseconds(GB_MIDI_DELAY);
+          sendByteToGameboy(rx.byte3);
+          delayMicroseconds(GB_MIDI_DELAY);
+          break;
+        default:
+          return;
+        }
+
+        statusLedOn();
+      } while (rx.header != 0);
 #endif
 }

--- a/Arduinoboy/Mode_Programmer.ino
+++ b/Arduinoboy/Mode_Programmer.ino
@@ -34,7 +34,7 @@ void programmerSendSettings()
   memcpy(&sysexData[3], memory, MEM_MAX+1);
   sysexData[MEM_MAX+3] = 0xF7;
   serial->write(sysexData, MEM_MAX+4);
-#ifdef MIDI_INTERFACE
+#ifdef USE_TEENSY
   usbMIDI.sendSysEx(MEM_MAX+4, sysexData);
 #endif
 }
@@ -43,7 +43,7 @@ void setProgrammerRequestConnect()
 {
   uint8_t data[4] = {0xF0,sysexManufacturerId,65,0xF7};
   serial->write(data, 4);
-#ifdef MIDI_INTERFACE
+#ifdef USE_TEENSY
   usbMIDI.sendSysEx(4, data);
 #endif
 }
@@ -85,7 +85,7 @@ void programmerSendConnectRequest()
   if(millis() > (sysexProgrammerLastSent+sysexProgrammerCallTime)) {
     uint8_t data[6] = {0xF0, sysexManufacturerId, 0x7F, defaultMemoryMap[MEM_VERSION_FIRST], defaultMemoryMap[MEM_VERSION_SECOND], 0xF7};
     serial->write(data, 6);
-#ifdef MIDI_INTERFACE
+#ifdef USE_TEENSY
     usbMIDI.sendSysEx(6, data);
 #endif
     sysexProgrammerLastSent = millis();
@@ -120,7 +120,9 @@ void clearSysexBuffer()
 void setMode(byte mode)
 {
   memory[MEM_MODE] = mode;
+  #ifndef USE_DUE
   EEPROM.write(MEM_MODE, memory[MEM_MODE]);
+  #endif
   showSelectedMode();
   switchMode();
 }
@@ -129,7 +131,7 @@ void sendMode()
 {
   uint8_t data[4] = {0xF0, sysexManufacturerId, memory[MEM_MODE], 0xF7};
   serial->write(data, 4);
-#ifdef MIDI_INTERFACE
+#ifdef USE_TEENSY
   usbMIDI.sendSysEx(4, data);
 #endif
 }

--- a/Arduinoboy/UsbMidi.ino
+++ b/Arduinoboy/UsbMidi.ino
@@ -1,5 +1,5 @@
 
-#ifndef MIDI_INTERFACE
+#ifndef USE_TEENSY
 void usbMidiSendTwoByteMessage(uint8_t b1, uint8_t b2) {};
 void usbMidiSendThreeByteMessage(uint8_t b1, uint8_t b2, uint8_t b3) {};
 void usbMidiSendRTMessage(uint8_t b) {};
@@ -91,3 +91,25 @@ void usbMidiInit()
 }
 
 #endif
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,17 @@
 ## Changelog
 
+### 05/17/20
+* Arduinoboy to version 1.3.3
+* Added support for Arduino Due
+
+### 05/03/20
+* Arduinoboy to version 1.3.2
+* Added support for Arduino Leonardo/Yún/Micro (ATmega32U4) (only Leonardo tested)
+
+### 04/19/20
+* Arduinoboy to version 1.3.1
+* Fixed Nanoloop sync through USB (teensy and Leonardo tested)
+
 ### 07/10/16
 * New Version 1.3.0a, please download from the [Releases] (https://github.com/trash80/Arduinoboy/releases) if you want the most recent stable version.
 * Added Teensy 3.x & LC support. Check the main file for the pin configuration.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ It works with the old DMG Gameboy as well as GBC/GBA.
 #### Mode 6 LSDJ MIDIMAP 
 Lsdj will sync to incoming MIDI sync, and incoming MIDI notes are mapped to LSDJ's song row #. The currently selected row's MIDI note is displayed on the top right of the LSDJ screen, and incoming MIDI notes will also display the relative song row number in the same location.
 
-In LSDJ the `sync` mode should be set to `Live/Sync`. 
+In LSDJ the `sync` mode should be set to `MI.MAP`. 
 
 *This requires a special version of LSDJ, which can be found in your account on the [LSDJ website](http://littlesounddj.com/lsd/latest/full_version/).*
 


### PR DESCRIPTION
Also, added full support for Arduino Leonardo, so the original shell used with Arduino UNO is fully compatible with Leonardo/Yún, but also capable of managing MIDI data through its Micro USB (as Teensy does). Arduino Micro should work, but another shield is needed (or connecting the pins to the produced shield with wires). Had to fix #9 to make mGB mode working.

Arduino Due support is also added (omitting EEPROM support and managing pins with 32-bits instead of 8).

All Arduinoboy modes were tested twice to check regressions and new features with all Arduino UNO (Rev3 and Rev3 SMD), Arduino Leonardo (both MIDI interface and Micro USB), Arduino Due (MIDI and Micro USB) and Teensyboy Pro (MIDI and Micro USB too).