### PR TITLE
Added support for modified mGB versions with extended MIDI channels

### DIFF
--- a/Arduinoboy/Arduinoboy.ino
+++ b/Arduinoboy/Arduinoboy.ino
@@ -76,7 +76,7 @@
  *                                                                         *
  ***************************************************************************/
 #include <EEPROM.h>
-#define MEM_MAX 65
+#define MEM_MAX 75
 #define NUMBER_OF_MODES 7    //Right now there are 7 modes, Might be more in the future
 
 //!!! do not edit these, they are the position in EEPROM memory that contain the value of each stored setting
@@ -101,10 +101,10 @@
 #define MEM_MIDIOUT_CC_NUMBERS 27
 
 #define MEM_MGB_CH 55
-#define MEM_LIVEMAP_CH 60
+#define MEM_LIVEMAP_CH 70
 
-#define MEM_MIDIOUT_BIT_DELAY 61
-#define MEM_MIDIOUT_BYTE_DELAY 63
+#define MEM_MIDIOUT_BIT_DELAY 71
+#define MEM_MIDIOUT_BYTE_DELAY 73
 
 /***************************************************************************
 * User Settings
@@ -137,6 +137,9 @@ byte defaultMemoryMap[MEM_MAX] = {
   1,2,3,7,10,11,12, //noi
 
   0, 1, 2, 3, 4, //mGB midi channels (0-15 = 1-16)
+  5, 6, 7, 8, 9, //mGB midi channels (0-15 = 1-16)
+  10, 11, 12, 13, 14, //mGB midi channels (0-15 = 1-16)
+
   0, //sync map midi channel start (0-15 = 1-16) (for song rows 0x80 to 0xFF it's this channel plus 1)
   80,1,  //midiout bit check delay & bit check delay multiplier
   0,0//midiout byte received delay & byte received delay multiplier

--- a/Arduinoboy/Mode_MidiGb.ino
+++ b/Arduinoboy/Mode_MidiGb.ino
@@ -60,6 +60,36 @@ void modeMidiGb()
             } else if (midiStatusChannel == memory[MEM_MGB_CH+4]) {
                midiData[0] = midiStatusType+4;
                sendByte = true;
+            } else if (midiStatusChannel == memory[MEM_MGB_CH+5]) {
+               midiData[0] = midiStatusType+5;
+               sendByte = true;
+            } else if (midiStatusChannel == memory[MEM_MGB_CH+6]) {
+               midiData[0] = midiStatusType+6;
+               sendByte = true;
+            } else if (midiStatusChannel == memory[MEM_MGB_CH+7]) {
+               midiData[0] = midiStatusType+7;
+               sendByte = true;
+            } else if (midiStatusChannel == memory[MEM_MGB_CH+8]) {
+               midiData[0] = midiStatusType+8;
+               sendByte = true;
+            } else if (midiStatusChannel == memory[MEM_MGB_CH+9]) {
+               midiData[0] = midiStatusType+9;
+               sendByte = true;
+            } else if (midiStatusChannel == memory[MEM_MGB_CH+10]) {
+               midiData[0] = midiStatusType+10;
+               sendByte = true;
+            } else if (midiStatusChannel == memory[MEM_MGB_CH+11]) {
+               midiData[0] = midiStatusType+11;
+               sendByte = true;
+            } else if (midiStatusChannel == memory[MEM_MGB_CH+12]) {
+               midiData[0] = midiStatusType+12;
+               sendByte = true;
+            } else if (midiStatusChannel == memory[MEM_MGB_CH+13]) {
+               midiData[0] = midiStatusType+13;
+               sendByte = true;
+            } else if (midiStatusChannel == memory[MEM_MGB_CH+14]) {
+               midiData[0] = midiStatusType+14;
+               sendByte = true;
             } else {
               midiValueMode  =false;
               midiAddressMode=false;
@@ -140,6 +170,36 @@ void modeMidiGbUsbMidiReceive()
             send = true;
         } else if (ch == memory[MEM_MGB_CH+4]) {
             ch = 4;
+            send = true;
+        } else if (ch == memory[MEM_MGB_CH+5]) {
+            ch = 5;
+            send = true;
+        } else if (ch == memory[MEM_MGB_CH+6]) {
+            ch = 6;
+            send = true;
+        } else if (ch == memory[MEM_MGB_CH+7]) {
+            ch = 7;
+            send = true;
+        } else if (ch == memory[MEM_MGB_CH+8]) {
+            ch = 8;
+            send = true;
+        } else if (ch == memory[MEM_MGB_CH+9]) {
+            ch = 9;
+            send = true;
+        } else if (ch == memory[MEM_MGB_CH+10]) {
+            ch = 10;
+            send = true;
+        } else if (ch == memory[MEM_MGB_CH+11]) {
+            ch = 11;
+            send = true;
+        } else if (ch == memory[MEM_MGB_CH+12]) {
+            ch = 12;
+            send = true;
+        } else if (ch == memory[MEM_MGB_CH+13]) {
+            ch = 13;
+            send = true;
+        } else if (ch == memory[MEM_MGB_CH+14]) {
+            ch = 14;
             send = true;
         }
         if(!send) return;


### PR DESCRIPTION
Support for 1-5, 6-10, 11-15 MIDI channels for mGB using modified versions of mGB 1.3.0 (https://github.com/lpla/mGB/tree/master/Releases).

From #11, if you connect three Game Boys with something like Synccross (https://github.com/lpla/synccross) and the Arduinoboy (with both master branch and my modifications), using stock mGB all Game Boys respond to the same 5 MIDI channels (which is 1 to 5 as hardcoded in mGB).

But with the modified mGB versions I linked, with master branch code you can only manage 5 channels, modifying them with the Max editor. Like, the PU1 of GB1, the PU1 of GB2, Poly of GB3, Noise of GB1 and Noise of GB2, for example, by mapping the editor channel values with the ones that the modified mGB's respond (let's say, MIDI 1, 6, 15, 4 and 9 respectively). But all the other Game Boy channels cannot be controlled.

With my changes you can use all channels and poly modes of all Game Boys at the same time independently, and still one MIDI channel is left unused.

This could lead to much information driven by the Link Cable and processed in all Game Boys, even if those MIDI bytes are not played, which could be an issue with the DMG/MGB consoles. This case could happen if many CC, sweep and notes are happening.

I tested with two GBC and one MGB (pocket) playing a 12 MIDI track improvisation (recorded each track in Logic Pro X and then played all together through the 4 channels of the 3 Game Boys). As only notes were used, it worked well.

Video demo in Discord: https://discordapp.com/channels/337974510210777088/337975587438329859/703662739192545292

Also tested using the six PU channels of the three Game Boys as a Poly organ synth:
https://discordapp.com/channels/337974510210777088/337975587438329859/704408638374281217