### PR TITLE
Deleted PS2 port code, fixes #17

### DIFF
--- a/Arduinoboy/Arduinoboy.ino
+++ b/Arduinoboy/Arduinoboy.ino
@@ -194,8 +194,6 @@ int pinButtonMode = 3; //toggle button for selecting the mode
 
 HardwareSerial *serial = &Serial1;
 
-byte incomingPS2Byte;
-
 
 /***************************************************************************
 * Arduino Due (ATmSAM3X8E)
@@ -221,8 +219,6 @@ int pinButtonMode = 3; //toggle button for selecting the mode
 
 HardwareSerial *serial = &Serial;
 
-byte incomingPS2Byte;
-
 
 /***************************************************************************
 * Arduino UNO/Ethernet/Nano (ATmega328), Arduino UNO Wifi (ATmega4809) or Mega 2560 (ATmega2560/ATmega1280) (assumed)
@@ -247,8 +243,6 @@ int pinLeds[] = {12,11,10,9,8,13}; // LED Pins
 int pinButtonMode = 3; //toggle button for selecting the mode
 
 HardwareSerial *serial = &Serial;
-
-byte incomingPS2Byte;
 
 #endif
 

--- a/Arduinoboy/Arduinoboy.ino
+++ b/Arduinoboy/Arduinoboy.ino
@@ -179,12 +179,7 @@ HardwareSerial *serial = &Serial1;
 #elif defined (__AVR_ATmega32U4__)
 #define USE_LEONARDO
 #include <MIDIUSB.h>
-#include <PS2Keyboard.h>
 
-// values for the PS/2 Keyboard input
-#define PS2_DATA_PIN 7
-#define PS2_CLOCK_PIN 3
-PS2Keyboard keyboard;
 #define GB_SET(bit_cl, bit_out, bit_in) PORTF = (PINF & B00011111) | ((bit_cl<<7) | ((bit_out)<<6) | ((bit_in)<<5))
 // ^ The reason for not using digitalWrite is to allign clock and data pins for the GB shift reg.
 // Pin distribution comes from official Arduino Leonardo documentation
@@ -210,14 +205,7 @@ byte incomingPS2Byte;
 
 #define USE_LEONARDO
 #include <MIDIUSB.h>
-#include <PS2Keyboard.h>
 #include <digitalWriteFast.h>
-
-
-// values for the PS/2 Keyboard input
-#define PS2_DATA_PIN 7
-#define PS2_CLOCK_PIN 3
-PS2Keyboard keyboard;
 
 
 #define GB_SET(bit_cl, bit_out, bit_in) digitalWriteFast(A0, bit_cl); digitalWriteFast(A1, bit_out); digitalWriteFast(A2, bit_in);
@@ -240,12 +228,7 @@ byte incomingPS2Byte;
 * Arduino UNO/Ethernet/Nano (ATmega328), Arduino UNO Wifi (ATmega4809) or Mega 2560 (ATmega2560/ATmega1280) (assumed)
 ***************************************************************************/
 #else
-#include <PS2Keyboard.h>
 
-// values for the PS/2 Keyboard input
-#define PS2_DATA_PIN 7
-#define PS2_CLOCK_PIN 3
-PS2Keyboard keyboard;
 #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
 #define GB_SET(bit_cl,bit_out,bit_in) PORTF = (PINF & B11111000) | ((bit_in<<2) | ((bit_out)<<1) | bit_cl)
 #elif defined(__AVR_ATmega4809__)

--- a/Arduinoboy/Mode_LSDJ_Keyboard.ino
+++ b/Arduinoboy/Mode_LSDJ_Keyboard.ino
@@ -19,9 +19,6 @@ void modeLSDJKeyboardSetup()
  #ifdef USE_TEENSY
   usbMIDI.setHandleRealTimeSystem(NULL);
  #endif
- #ifndef USE_USB
-  keyboard.begin(PS2_DATA_PIN, PS2_CLOCK_PIN);
- #endif
   blinkMaxCount=1000;
 
   /* The stuff below makes sure the code is in the same state as LSDJ on reset / restart, mode switched, etc. */
@@ -42,14 +39,6 @@ void modeLSDJKeyboardSetup()
 void modeLSDJKeyboard()
 {
   while(1){                              //Loop foreverrrr
- #ifndef USE_USB
-  if (keyboard.available()) {
-    incomingPS2Byte = keyboard.readScanCode();
-    if (incomingPS2Byte) {
-     sendKeyboardByteToGameboy(incomingPS2Byte);
-    }
-  }
- #endif
   modeLSDJKeyboardMidiReceive();
   if (serial->available()) {          //If MIDI is sending
     incomingMidiByte = serial->read();    //Get the byte sent from MIDI


### PR DESCRIPTION
Deleted PS2 code, only works if you have a PS2 port in your Arduinoboy and it depends on an external library. Kept in my fork.