### PR TITLE
Removing comments to fix correct values in midi CC

### DIFF
--- a/Arduinoboy/Mode_LSDJ_Midiout.ino
+++ b/Arduinoboy/Mode_LSDJ_Midiout.ino
@@ -173,10 +173,10 @@ void playCC(byte m, byte n)
   byte v = n;
 
   if(memory[MEM_MIDIOUT_CC_MODE+m]) {
-//    if(memory[MEM_MIDIOUT_CC_SCALING+m]) {
-//      v = (v & 0x0F)*8;
-//      //if(v) v --;
-//    }
+    if(memory[MEM_MIDIOUT_CC_SCALING+m]) {
+      v = (v & 0x0F)*8;
+      //if(v) v --;
+    }
     n=(m*7)+((n>>4) & 0x07);
     midiData[0] = (0xB0 + (memory[MEM_MIDIOUT_CC_CH+m]));
     midiData[1] = (memory[MEM_MIDIOUT_CC_NUMBERS+n]);


### PR DESCRIPTION
As a mistake while testing #13, kept commented 4 lines that correct MIDI CC values. This pull request remove those comments (thank you @farvardin for pointing it out [here](https://github.com/trash80/Arduinoboy/commit/53525ebf78ef6e69d8f9c36cba6ad5925d4eaa5e#commitcomment-41316479)!)